### PR TITLE
Update Jenkins job template

### DIFF
--- a/charts/apim-gw-cicd/values.yaml
+++ b/charts/apim-gw-cicd/values.yaml
@@ -55,7 +55,7 @@ jenkins:
         <keepDependencies>false</keepDependencies>
         <properties>
             <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.29.3">
-                <projectUrl>https://github.com/kmienata/puma-ephemeral-gateway-config.git/</projectUrl>
+                <projectUrl>https://github.com/CAAPIM/ephemeral-gateway-skeleton-repo/</projectUrl>
                 <displayName></displayName>
             </com.coravy.hudson.plugins.github.GithubProjectProperty>
             <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
@@ -71,7 +71,7 @@ jenkins:
                 <configVersion>2</configVersion>
                 <userRemoteConfigs>
                     <hudson.plugins.git.UserRemoteConfig>
-                        <url>https://github.com/kmienata/puma-ephemeral-gateway-config.git</url>
+                        <url>https://github.com/CAAPIM/ephemeral-gateway-skeleton-repo</url>
                     </hudson.plugins.git.UserRemoteConfig>
                 </userRemoteConfigs>
                 <branches>


### PR DESCRIPTION
Jenkins job template Git repository is changed to point to a public CAAPIM ephemeral gateway skeleton repo.